### PR TITLE
Add UseAllSpecs to apiselector schema

### DIFF
--- a/apiselector.json
+++ b/apiselector.json
@@ -132,6 +132,10 @@
           "type": "boolean",
           "description": "Controls the generation of all the APIs in the CI specs directory, Default: false"
         },
+        "UseAllSpecs": {
+          "type": "boolean",
+          "description": "Controls the generation of all the APIs in the CI specs directory including ignored specs, Default: false"
+        },
         "UseGlobalApis": {
           "type": "boolean",
           "description": "Controls the inclusion of global apis in local apis, Default: true"


### PR DESCRIPTION
## Summary
Add the missing `UseAllSpecs` boolean property to the `ApiConfig` definition in `apiselector.json`.

## Why
`APIMatic.TestConsole` already supports `UseAllSpecs` in the API selector config, but the published JSON schema does not expose it. This causes schema validation and editor IntelliSense to lag behind the actual supported setting.

## Validation
- Parsed `apiselector.json` successfully after the change
- Verified the diff is limited to the new `UseAllSpecs` property
